### PR TITLE
Fix panic on i686-unknown-linux-gnu

### DIFF
--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -156,7 +156,6 @@ impl<'a> SharedLibraryTrait for SharedLibrary<'a> {
 
     #[inline]
     fn virtual_memory_bias(&self) -> Bias {
-        assert!((self.addr as usize) < (isize::MAX as usize));
         Bias(self.addr as usize as isize)
     }
 


### PR DESCRIPTION
On i686-unknown-linux-gnu libraries frequently get loaded at high addresses (0xf...), triggering this assert. Removing it made the code work correctly for me. I am adding the resulting bias to a symbol offset that I'm getting from the corresponding .so file, and getting the correct pointer as intended.